### PR TITLE
Warn and link to Tesseract-OCR if not installed

### DIFF
--- a/crates/jpv-lib/src/api.rs
+++ b/crates/jpv-lib/src/api.rs
@@ -69,12 +69,53 @@ impl Request for GetConfig {
     type Response = GetConfigResult;
 }
 
+/// Missing OCR support.
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstallUrl {
+    /// Title of the URL.
+    pub text: String,
+    /// Hover title.
+    pub title: String,
+    /// The URL where to install it from.
+    pub url: String,
+}
+
+/// Missing OCR support.
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MissingOcr {
+    /// The URL where to install it from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_url: Option<InstallUrl>,
+}
+
+impl MissingOcr {
+    #[cfg(unix)]
+    pub fn for_platform() -> Self {
+        Self { install_url: None }
+    }
+
+    #[cfg(windows)]
+    pub fn for_platform() -> Self {
+        Self {
+            install_url: Some(InstallUrl {
+                text: "Install Tesseract-OCR".to_string(),
+                title: "Download and install Tesseract-OCR from UB-Mannheim.\nDon't forget to add Japanese as additional script!".to_string(),
+                url: "https://github.com/UB-Mannheim/tesseract/wiki".to_string(),
+            }),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetConfigResult {
     /// System configuration.
     pub config: Config,
     /// Installed dictionaries.
+    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub installed: HashSet<String>,
+    /// Indicates that OCR support is missing, and some indications of how to install it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub missing_ocr: Option<MissingOcr>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/jpv-lib/src/config.rs
+++ b/crates/jpv-lib/src/config.rs
@@ -57,6 +57,13 @@ pub struct Config {
     /// Enabled indexes.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub indexes: BTreeMap<String, ConfigIndex>,
+    /// Whether OCR support is enabled or not.
+    #[serde(default = "default_ocr")]
+    pub ocr: bool,
+}
+
+fn default_ocr() -> bool {
+    true
 }
 
 impl Config {
@@ -133,6 +140,6 @@ impl Default for Config {
             },
         );
 
-        Self { indexes }
+        Self { indexes, ocr: true }
     }
 }

--- a/crates/jpv/src/reporter.rs
+++ b/crates/jpv/src/reporter.rs
@@ -4,12 +4,12 @@ use std::sync::{Arc, RwLock};
 use lib::api;
 use lib::reporter::{Reporter, TracingReporter};
 
-use crate::background::BackgroundInner;
+use crate::background::Mutable;
 use crate::system::{Event, SystemEvents};
 
 pub(crate) struct EventsReporter {
     pub(crate) parent: TracingReporter,
-    pub(crate) inner: Arc<RwLock<BackgroundInner>>,
+    pub(crate) inner: Arc<RwLock<Mutable>>,
     pub(crate) system_events: SystemEvents,
     pub(crate) name: Option<Box<str>>,
 }

--- a/crates/jpv/src/web/ws.rs
+++ b/crates/jpv/src/web/ws.rs
@@ -388,9 +388,16 @@ async fn run(
                             api::GetConfig::KIND => {
                                 let database = bg.database();
 
+                                let missing_ocr = if bg.tesseract().is_none() {
+                                    Some(api::MissingOcr::for_platform())
+                                } else {
+                                    None
+                                };
+
                                 let result = api::GetConfigResult {
                                     config: bg.config(),
                                     installed: database.installed()?,
+                                    missing_ocr,
                                 };
 
                                 Ok(serde_json::to_value(&result)?)


### PR DESCRIPTION
This happens on Windows when the Tesseract-OCR package has not been installed, or the japanese language pack could not be loaded.

The link sends you to [UB-Mannheim and their installer](https://github.com/UB-Mannheim/tesseract/wiki). Installing it and restarting the background service will get rid of the warning. So will disabling OCR support in options.

![image](https://github.com/udoprog/jpv/assets/111092/010e77d1-6183-45ca-a400-b9dbcf49494f)
