### PR TITLE
Insert romanized and katakana readings of conjugations

### DIFF
--- a/crates/jpv-lib/src/lib.rs
+++ b/crates/jpv-lib/src/lib.rs
@@ -8,7 +8,7 @@
 /// Dictionary magic `JPVD`.
 pub const DICTIONARY_MAGIC: u32 = 0x4a_50_56_44;
 /// Current database version in use.
-pub const DICTIONARY_VERSION: u32 = 3;
+pub const DICTIONARY_VERSION: u32 = 4;
 
 /// Helper to convert a type to its owned variant.
 pub use ::borrowme::to_owned;

--- a/crates/jpv/src/command/cli.rs
+++ b/crates/jpv/src/command/cli.rs
@@ -9,7 +9,7 @@ use anyhow::{bail, Result};
 use clap::Parser;
 use lib::config::Config;
 use lib::data;
-use lib::database::{Database, Entry, Id, IndexSource};
+use lib::database::{Database, Entry, Id, Source};
 use lib::inflection;
 use lib::{Dirs, Form, Furigana, PartOfSpeech};
 
@@ -176,7 +176,7 @@ fn print_rich<O>(
 where
     O: ?Sized + Write,
 {
-    if let IndexSource::Inflection { inflection, .. } = id.source() {
+    if let Source::Inflection { inflection, .. } = id.source() {
         writeln!(o, "Found through inflection: {inflection:?}")?;
     }
 

--- a/crates/web/src/components/entry.rs
+++ b/crates/web/src/components/entry.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use lib::database::IndexSource;
+use lib::database::Source;
 use lib::entities::KanjiInfo;
 use lib::jmdict::{
     OwnedExample, OwnedExampleSentence, OwnedKanjiElement, OwnedReadingElement, OwnedSense,
@@ -70,7 +70,7 @@ pub(crate) struct Entry {
 #[derive(Properties)]
 pub struct Props {
     pub embed: bool,
-    pub sources: BTreeSet<IndexSource>,
+    pub sources: BTreeSet<Source>,
     pub entry: jmdict::OwnedEntry,
     pub onchange: Callback<(String, Option<String>), ()>,
 }
@@ -391,11 +391,11 @@ impl Entry {
 
 /// Find the matching inflection based on the source.
 fn find_inflection<'a>(
-    source: &IndexSource,
+    source: &Source,
     inflections: &'a [(inflection::Reading, OwnedInflections)],
 ) -> Option<(Inflection, &'a OwnedInflections)> {
     match source {
-        IndexSource::Inflection {
+        Source::Inflection {
             reading,
             inflection,
         } => {

--- a/crates/web/src/components/name.rs
+++ b/crates/web/src/components/name.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use lib::database::IndexSource;
+use lib::database::Source;
 use lib::{jmnedict, kana};
 use yew::prelude::*;
 
@@ -11,7 +11,7 @@ pub enum Msg {}
 #[derive(Properties, PartialEq)]
 pub struct Props {
     pub embed: bool,
-    pub sources: BTreeSet<IndexSource>,
+    pub sources: BTreeSet<Source>,
     pub entry: jmnedict::OwnedEntry,
 }
 


### PR DESCRIPTION
This allows for efficiently searching using romanized or katakana phrases directly.

This does increase the size of the database a bit (total size is about 1.6G now), and especially memory use as it's being built, so beware. At some point I might offload that work onto disk which will slow down the process but make it easier to use on systerms with less memory. Alternatively, I might just host the dictionaries somewhere.