### PR TITLE
Add ability to store and fetch radicals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,6 +1353,7 @@ dependencies = [
  "anyhow",
  "borrowme",
  "directories",
+ "encoding_rs",
  "fixed-map",
  "log",
  "memmap",

--- a/crates/jpv-lib/Cargo.toml
+++ b/crates/jpv-lib/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "1.0.50"
 directories = "5.0.1"
 toml = "0.8.8"
 serde_json = "1.0.108"
+encoding_rs = "0.8.33"
 
 [target.'cfg(any(unix, windows))'.dependencies]
 memmap = { version = "0.7.0", optional = true }

--- a/crates/jpv-lib/src/api.rs
+++ b/crates/jpv-lib/src/api.rs
@@ -271,7 +271,10 @@ pub struct EntryResponse<'a> {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct KanjiResponse<'a> {
     #[borrowed_attr(serde(borrow))]
-    pub entry: kanjidic2::Character<'a>,
+    pub kanji: kanjidic2::Character<'a>,
+    #[borrowed_attr(serde(borrow))]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub radicals: Vec<&'a str>,
 }
 
 #[borrowme::borrowme]

--- a/crates/jpv-lib/src/database/stored.rs
+++ b/crates/jpv-lib/src/database/stored.rs
@@ -28,6 +28,8 @@ pub(super) struct IndexHeader {
     pub(super) lookup: trie::TrieRef<Id, CompactTrie>,
     pub(super) by_pos: swiss::MapRef<PartOfSpeech, Ref<[PhrasePos]>>,
     pub(super) by_kanji_literal: swiss::MapRef<Ref<str>, u32>,
+    pub(super) radicals: swiss::MapRef<Ref<str>, u32>,
+    pub(super) radicals_to_kanji: swiss::MapRef<Ref<str>, Ref<[u32]>>,
     pub(super) by_sequence: swiss::MapRef<u32, PhrasePos>,
     pub(super) inflections: Ref<[InflectionData]>,
 }

--- a/crates/jpv-lib/src/kradfile/mod.rs
+++ b/crates/jpv-lib/src/kradfile/mod.rs
@@ -1,0 +1,106 @@
+use std::str;
+
+use encoding_rs::{DecoderResult, EUC_JP};
+use musli::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+
+const NUL: u8 = 0;
+
+/// An entry.
+#[borrowme::borrowme]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Encode, Decode)]
+#[musli(packed)]
+pub struct Entry<'a> {
+    pub kanji: &'a str,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub radicals: Vec<&'a str>,
+}
+
+/// A KRADFILE parser.
+pub struct Parser<'a> {
+    input: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Parser<'a> {
+    /// Construct a new KRADFILE parser.
+    pub fn new(input: &'a [u8]) -> Self {
+        Self { input, pos: 0 }
+    }
+
+    /// Step to the next byte.
+    pub fn advance(&mut self) {
+        self.pos = self.pos.saturating_add(1).min(self.input.len());
+    }
+
+    /// Peek the next byte.
+    pub fn peek(&mut self) -> u8 {
+        let Some(byte) = self.input.get(self.pos) else {
+            return NUL;
+        };
+
+        *byte
+    }
+
+    fn is_eof(&self) -> bool {
+        self.pos >= self.input.len()
+    }
+
+    /// Parse an entry.
+    pub fn parse(&mut self) -> Option<OwnedEntry> {
+        let mut buf = [0; 2048];
+
+        while !self.is_eof() {
+            while self.peek().is_ascii_whitespace() {
+                self.advance();
+            }
+
+            if self.peek() == b'#' {
+                while !matches!(self.peek(), b'\n' | NUL) {
+                    self.advance();
+                }
+
+                continue;
+            }
+
+            let start = self.pos;
+
+            while !matches!(self.peek(), b'\n' | NUL) {
+                self.advance();
+            }
+
+            let end = self.pos;
+            self.advance();
+
+            let mut decoder = EUC_JP.new_decoder();
+            let (result, _, written) =
+                decoder.decode_to_utf8_without_replacement(&self.input[start..end], &mut buf, true);
+
+            match result {
+                DecoderResult::InputEmpty => {}
+                DecoderResult::OutputFull => {
+                    continue;
+                }
+                DecoderResult::Malformed(..) => {
+                    continue;
+                }
+            }
+
+            let Ok(line) = str::from_utf8(&buf[..written]) else {
+                continue;
+            };
+
+            let Some((kanji, remainder)) = line.split_once(" : ") else {
+                continue;
+            };
+
+            let radicals = remainder.split_whitespace().map(str::to_owned).collect();
+            return Some(OwnedEntry {
+                kanji: kanji.to_owned(),
+                radicals,
+            });
+        }
+
+        None
+    }
+}

--- a/crates/jpv-lib/src/lib.rs
+++ b/crates/jpv-lib/src/lib.rs
@@ -8,7 +8,7 @@
 /// Dictionary magic `JPVD`.
 pub const DICTIONARY_MAGIC: u32 = 0x4a_50_56_44;
 /// Current database version in use.
-pub const DICTIONARY_VERSION: u32 = 6;
+pub const DICTIONARY_VERSION: u32 = 7;
 
 /// Helper to convert a type to its owned variant.
 pub use ::borrowme::to_owned;
@@ -46,6 +46,7 @@ mod sort_key;
 pub mod jmdict;
 pub mod jmnedict;
 pub mod kanjidic2;
+pub mod kradfile;
 
 pub mod entities;
 pub use self::entities::{Entity, PartOfSpeech};

--- a/crates/jpv-tesseract/src/error.rs
+++ b/crates/jpv-tesseract/src/error.rs
@@ -79,5 +79,6 @@ pub(super) enum ErrorKind {
     MissingLanguage(Box<Path>),
     #[error("Platform is not supported")]
     #[cfg(any(windows, not(feature = "linked")))]
+    #[allow(unused)]
     Unsupported,
 }

--- a/crates/jpv/src/command/build.rs
+++ b/crates/jpv/src/command/build.rs
@@ -40,6 +40,8 @@ pub(crate) async fn run(
 
     let to_download = crate::background::config_to_download(&config, dirs, overrides);
 
+    let force_all = build_args.force.first().map_or(false, |v| v == "all");
+
     for to_download in to_download {
         let tracing_reporter = Arc::new(EmptyReporter);
         let (_sender, shutdown) = oneshot::channel();
@@ -49,7 +51,7 @@ pub(crate) async fn run(
             shutdown,
             dirs,
             &to_download,
-            build_args.force.contains(&to_download.name),
+            force_all || build_args.force.contains(&to_download.name),
         )
         .await?;
     }

--- a/crates/jpv/src/web/mod.rs
+++ b/crates/jpv/src/web/mod.rs
@@ -140,8 +140,13 @@ async fn kanji(
         )));
     };
 
+    let radicals = db.literal_to_radicals(&literal)?;
+
     Ok(Json(api::OwnedKanjiResponse {
-        entry: lib::to_owned(entry),
+        kanji: lib::to_owned(entry),
+        radicals: radicals
+            .map(|e| lib::to_owned(e.radicals))
+            .unwrap_or_default(),
     }))
 }
 

--- a/crates/jpv/src/web/ws.rs
+++ b/crates/jpv/src/web/ws.rs
@@ -256,7 +256,7 @@ async fn handle_image(
     let data = image.as_bytes();
     let width = usize::try_from(image.width())?;
     let height = usize::try_from(image.height())?;
-    let bytes_per_pixel = usize::try_from(image.color().bytes_per_pixel())?;
+    let bytes_per_pixel = usize::from(image.color().bytes_per_pixel());
 
     tracing::trace!(len = data.len(), width, height, bytes_per_pixel);
 

--- a/crates/web/src/components/edit_index.rs
+++ b/crates/web/src/components/edit_index.rs
@@ -218,14 +218,18 @@ impl Component for EditIndex {
             .as_ref()
             .map(|error| html!(<p class="form-error">{error.clone()}</p>));
 
+        let options = IndexFormat::all().into_iter().map(|format| {
+            html! {
+                <option value={format.id()} selected={self.format == format}>{format.description()}</option>
+            }
+        });
+
         html! {
             <div {class}>
                 <div class="block form">
                     <h6>{"Format"}</h6>
                     <select onchange={onchangeformat}>
-                        <option value="jmdict" selected={self.format == IndexFormat::Jmdict}>{"JMDict"}</option>
-                        <option value="jmnedict" selected={self.format == IndexFormat::Jmnedict}>{"JMnedict"}</option>
-                        <option value="kanjidic2" selected={self.format == IndexFormat::Kanjidic2}>{"Kanjidic2"}</option>
+                        {for options}
                     </select>
                 </div>
                 {id}

--- a/crates/web/src/components/prompt.rs
+++ b/crates/web/src/components/prompt.rs
@@ -896,8 +896,10 @@ fn copyright() -> Html {
                 <a href="https://www.edrdg.org/wiki/index.php/JMdict-EDICT_Dictionary_Project">{"JMDICT"}</a>
                 <span>{", "}</span>
                 <a href="https://www.edrdg.org/wiki/index.php/KANJIDIC_Project">{"KANJIDIC2"}</a>
-                <span>{", and "}</span>
+                <span>{", "}</span>
                 <a href="http://edrdg.org/enamdict/enamdict_doc.html">{"ENAMDICT"}</a>
+                <span>{", and "}</span>
+                <a href="http://nihongo.monash.edu/kradinf.html">{"KRADFILE"}</a>
                 <span>{" which is the property of the "}</span>
                 <a href="https://www.edrdg.org">{"EDRDG"}</a>
                 <span>{" and is used in conformance with its "}</span>


### PR DESCRIPTION
This adds the ability to load radicals from the [KRADFILE project](http://nihongo.monash.edu/kradinf.html). These are currently only made visible (if enabled) through the kanji api (accessed by clicking Kanji) but is intended to be used in new Kanji-specific views soon.

For example, this is what you should see if you visit <http://localhost:44714/api/kanji/邉>.

![image](https://github.com/udoprog/jpv/assets/111092/475885f3-0a01-47fd-ae77-add99aa71978)
