### PR TITLE
Improve prompt and search

### DIFF
--- a/crates/jpv-lib/src/entities.rs
+++ b/crates/jpv-lib/src/entities.rs
@@ -3,20 +3,8 @@ use musli::{Decode, Encode};
 use musli_zerocopy::{Visit, ZeroCopy};
 use serde::{Deserialize, Serialize};
 
-macro_rules! pick {
-    ($entity:literal,) => {
-        $entity
-    };
-
-    ($entity:literal, $parse:literal) => {
-        $parse
-    };
-}
-
 macro_rules! entity {
     (
-        $enum_name:ident, $test:ident,
-
         $(
             $(#[$($meta:meta)*])*
             $vis:vis enum $name:ident {
@@ -24,35 +12,6 @@ macro_rules! entity {
             }
         )*
     ) => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-        #[non_exhaustive]
-        pub enum $enum_name {
-            $(
-                $name($name),
-            )*
-        }
-
-        impl $enum_name {
-            #[allow(unused)]
-            pub(crate) fn parse_keyword(string: &str) -> Option<$enum_name> {
-                match string {
-                    $(
-                        $(pick!($entity, $($parse)*) => Some($enum_name::$name($name::$variant)),)*
-                    )*
-                    _ => None,
-                }
-            }
-        }
-
-        #[test]
-        fn $test() {
-            $(
-                $(
-                    assert_eq!($enum_name::parse_keyword(pick!($entity, $($parse)*)), Some($enum_name::$name($name::$variant)), "Failed to parse `{}`", pick!($entity, $($parse)*));
-                )*
-            )*
-        }
-
         $(
             $(#[$($meta)*])*
             #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Key, ZeroCopy, Visit)]
@@ -72,13 +31,13 @@ macro_rules! entity {
                     $($name::$variant,)*
                 ];
 
-                $vis fn variant(&self) -> &str {
+                $vis fn variant(&self) -> &'static str {
                     match self {
                         $($name::$variant => stringify!($variant),)*
                     }
                 }
 
-                $vis fn ident(&self) -> &str {
+                $vis fn ident(&self) -> &'static str {
                     match self {
                         $($name::$variant => $entity,)*
                     }
@@ -109,8 +68,6 @@ macro_rules! entity {
 }
 
 entity! {
-    Entity, test_entity,
-
     #[derive(Encode, Decode, Serialize, Deserialize)]
     pub enum Miscellaneous {
         <Abbreviation "abbr" "abbreviation">
@@ -398,10 +355,6 @@ entity! {
         <VideoGames "vidg" "video games">
         <Zoology "zool" "zoology">
     }
-}
-
-entity! {
-    NameEntity, test_name_entity,
 
     #[derive(Encode, Decode, Serialize, Deserialize)]
     pub enum NameType {
@@ -431,5 +384,105 @@ entity! {
         <Surname "surname" "family or surname">
         <Unclassified "unclass" "unclassified name">
         <Work "work" "work of art, literature, music, etc. name">
+    }
+}
+
+impl PartOfSpeech {
+    /// Get a generic category for this part of speech.
+    pub(crate) fn generic(&self) -> Option<&'static str> {
+        match self {
+            PartOfSpeech::AdjectiveF => Some("adjective"),
+            PartOfSpeech::AdjectiveI => Some("adjective"),
+            PartOfSpeech::AdjectiveIx => Some("adjective"),
+            PartOfSpeech::AdjectiveKari => Some("adjective"),
+            PartOfSpeech::AdjectiveKu => Some("adjective"),
+            PartOfSpeech::AdjectiveNa => Some("adjective"),
+            PartOfSpeech::AdjectiveNari => Some("adjective"),
+            PartOfSpeech::AdjectiveNo => Some("adjective"),
+            PartOfSpeech::AdjectivePn => Some("adjective"),
+            PartOfSpeech::AdjectiveShiku => Some("adjective"),
+            PartOfSpeech::AdjectiveT => Some("adjective"),
+            PartOfSpeech::Adverb => Some("adverb"),
+            PartOfSpeech::AdverbTo => Some("adverb"),
+            PartOfSpeech::Auxiliary => Some("auxiliary"),
+            PartOfSpeech::AuxiliaryAdjective => Some("auxiliary"),
+            PartOfSpeech::AuxiliaryVerb => Some("auxiliary"),
+            PartOfSpeech::Conjunction => Some("conjunction"),
+            PartOfSpeech::Copular => Some("copular"),
+            PartOfSpeech::Counter => Some("counter"),
+            PartOfSpeech::Expression => Some("expression"),
+            PartOfSpeech::Interjection => Some("interjection"),
+            PartOfSpeech::Noun => Some("noun"),
+            PartOfSpeech::NounAdverbial => Some("noun"),
+            PartOfSpeech::NounProper => Some("noun"),
+            PartOfSpeech::NounPrefix => Some("noun"),
+            PartOfSpeech::NounSuffix => Some("noun"),
+            PartOfSpeech::NounTemporal => Some("noun"),
+            PartOfSpeech::Numeric => Some("numeric"),
+            PartOfSpeech::Pronoun => Some("pronoun"),
+            PartOfSpeech::Prefix => Some("prefix"),
+            PartOfSpeech::Particle => Some("particle"),
+            PartOfSpeech::Suffix => Some("suffix"),
+            PartOfSpeech::Unclassified => None,
+            PartOfSpeech::VerbUnspecified => Some("verb"),
+            PartOfSpeech::VerbIchidan => Some("verb"),
+            PartOfSpeech::VerbIchidanS => Some("verb"),
+            PartOfSpeech::VerbNidanAS => Some("verb"),
+            PartOfSpeech::VerbNidanBK => Some("verb"),
+            PartOfSpeech::VerbNidanBS => Some("verb"),
+            PartOfSpeech::VerbNidanDK => Some("verb"),
+            PartOfSpeech::VerbNidanDS => Some("verb"),
+            PartOfSpeech::VerbNidanGK => Some("verb"),
+            PartOfSpeech::VerbNidanGS => Some("verb"),
+            PartOfSpeech::VerbNidanHK => Some("verb"),
+            PartOfSpeech::VerbNidanHS => Some("verb"),
+            PartOfSpeech::VerbNidanKK => Some("verb"),
+            PartOfSpeech::VerbNidanKS => Some("verb"),
+            PartOfSpeech::VerbNidanMK => Some("verb"),
+            PartOfSpeech::VerbNidanMS => Some("verb"),
+            PartOfSpeech::VerbNidanNS => Some("verb"),
+            PartOfSpeech::VerbNidanRK => Some("verb"),
+            PartOfSpeech::VerbNidanRS => Some("verb"),
+            PartOfSpeech::VerbNidanSS => Some("verb"),
+            PartOfSpeech::VerbNidanTK => Some("verb"),
+            PartOfSpeech::VerbNidanTS => Some("verb"),
+            PartOfSpeech::VerbNidanWS => Some("verb"),
+            PartOfSpeech::VerbNidanYK => Some("verb"),
+            PartOfSpeech::VerbNidanYS => Some("verb"),
+            PartOfSpeech::VerbNidanZS => Some("verb"),
+            PartOfSpeech::VerbYodanB => Some("verb"),
+            PartOfSpeech::VerbYodanG => Some("verb"),
+            PartOfSpeech::VerbYodanH => Some("verb"),
+            PartOfSpeech::VerbYodanK => Some("verb"),
+            PartOfSpeech::VerbYodanM => Some("verb"),
+            PartOfSpeech::VerbYodanN => Some("verb"),
+            PartOfSpeech::VerbYodanR => Some("verb"),
+            PartOfSpeech::VerbYodanS => Some("verb"),
+            PartOfSpeech::VerbYodanT => Some("verb"),
+            PartOfSpeech::VerbGodanAru => Some("verb"),
+            PartOfSpeech::VerbGodanB => Some("verb"),
+            PartOfSpeech::VerbGodanG => Some("verb"),
+            PartOfSpeech::VerbGodanK => Some("verb"),
+            PartOfSpeech::VerbGodanKS => Some("verb"),
+            PartOfSpeech::VerbGodanM => Some("verb"),
+            PartOfSpeech::VerbGodanN => Some("verb"),
+            PartOfSpeech::VerbGodanR => Some("verb"),
+            PartOfSpeech::VerbGodanRI => Some("verb"),
+            PartOfSpeech::VerbGodanS => Some("verb"),
+            PartOfSpeech::VerbGodanT => Some("verb"),
+            PartOfSpeech::VerbGodanU => Some("verb"),
+            PartOfSpeech::VerbGodanUS => Some("verb"),
+            PartOfSpeech::VerbGodanUru => Some("verb"),
+            PartOfSpeech::VerbIntransitive => Some("verb"),
+            PartOfSpeech::VerbKuru => Some("verb"),
+            PartOfSpeech::VerbNu => Some("verb"),
+            PartOfSpeech::VerbRu => Some("verb"),
+            PartOfSpeech::VerbSuru => Some("verb"),
+            PartOfSpeech::VerbSuC => Some("verb"),
+            PartOfSpeech::VerbSuruIncluded => Some("verb"),
+            PartOfSpeech::VerbSuruSpecial => Some("verb"),
+            PartOfSpeech::VerbTransitive => Some("verb"),
+            PartOfSpeech::VerbZuru => Some("verb"),
+        }
     }
 }

--- a/crates/jpv-lib/src/jmnedict/elements.rs
+++ b/crates/jpv-lib/src/jmnedict/elements.rs
@@ -19,6 +19,13 @@ pub struct Entry<'a> {
 }
 
 impl Entry<'_> {
+    /// Return all unique entities associated with an entry.
+    pub fn visit_entities(&self, mut f: impl FnMut(&str)) {
+        for ty in &self.name_types {
+            f(ty.ident());
+        }
+    }
+
     /// Entry weight.
     pub fn weight(&self, input: &str) -> Weight {
         // Boost based on exact query.

--- a/crates/jpv-lib/src/lib.rs
+++ b/crates/jpv-lib/src/lib.rs
@@ -49,7 +49,7 @@ pub mod kanjidic2;
 pub mod kradfile;
 
 pub mod entities;
-pub use self::entities::{Entity, PartOfSpeech};
+pub use self::entities::PartOfSpeech;
 
 mod furigana;
 pub use self::furigana::{Furigana, FuriganaGroup};
@@ -62,6 +62,8 @@ mod priority;
 pub use self::priority::Priority;
 
 pub mod database;
+
+pub mod search;
 
 mod musli;
 

--- a/crates/jpv-lib/src/priority.rs
+++ b/crates/jpv-lib/src/priority.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use musli::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
@@ -88,5 +90,11 @@ impl Priority {
             PriorityKind::Spec => range!(2.0) * 2.2,
             PriorityKind::WordFrequency => range!(50.0) * 2.0,
         }
+    }
+}
+
+impl fmt::Display for Priority {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}{}", self.category(), self.level)
     }
 }

--- a/crates/web/src/components/analyze_toggle.rs
+++ b/crates/web/src/components/analyze_toggle.rs
@@ -6,8 +6,8 @@ use super::spacing;
 
 #[derive(Properties, PartialEq)]
 pub(crate) struct Props {
-    pub(crate) query: Rc<str>,
-    pub(crate) analyzed: Rc<[Rc<str>]>,
+    pub(crate) query: String,
+    pub(crate) analyzed: Rc<[String]>,
     pub(crate) index: usize,
     #[prop_or_default]
     pub(crate) analyze_at: Option<usize>,
@@ -34,7 +34,7 @@ impl Component for AnalyzeToggle {
             let sub = ctx.props().query.get(i..).unwrap_or_default();
 
             let event = if let (Some(analyze_at), Some(string)) = (ctx.props().analyze_at, string) {
-                if i == analyze_at && rem == 0 && sub.starts_with(string.as_ref()) {
+                if i == analyze_at && rem == 0 && sub.starts_with(string.as_str()) {
                     rem = string.chars().count();
                     None
                 } else {

--- a/crates/web/src/components/name.rs
+++ b/crates/web/src/components/name.rs
@@ -3,13 +3,16 @@ use yew::prelude::*;
 
 use super::{comma, romaji, ruby, seq};
 
-pub enum Msg {}
+pub enum Msg {
+    AddTag(&'static str),
+}
 
 #[derive(Properties, PartialEq)]
 pub struct Props {
     pub embed: bool,
     pub entry: jmnedict::OwnedEntry,
     pub onclick: Callback<String>,
+    pub ontag: Callback<&'static str>,
 }
 
 pub struct Name;
@@ -20,6 +23,16 @@ impl Component for Name {
 
     fn create(_: &Context<Self>) -> Self {
         Self
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Msg::AddTag(tag) => {
+                ctx.props().ontag.emit(tag);
+            }
+        }
+
+        false
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {
@@ -59,7 +72,7 @@ impl Component for Name {
             html!({for it})
         };
 
-        let bullets = bullets!(entry.name_types, "sm");
+        let bullets = bullets!(ctx, entry.name_types, "sm");
 
         html! {
             <span class="row">

--- a/crates/web/src/components/tools.rs
+++ b/crates/web/src/components/tools.rs
@@ -4,8 +4,10 @@ use std::iter;
 use yew::prelude::*;
 
 macro_rules! bullets {
-    ($base:ident . $name:ident $(, $($tt:tt)*)?) => {
-        $base.$name.iter().map(|d| {
+    ($ctx:expr, $base:ident . $name:ident $(, $($tt:tt)*)?) => {{
+        let onclick = $ctx.link().callback(Msg::AddTag);
+
+        $base.$name.iter().map(move |d| {
             let class = classes! {
                 "bullet",
                 stringify!($name),
@@ -13,9 +15,11 @@ macro_rules! bullets {
                 $($($tt)*)*
             };
 
-            html!(<span class={class} title={d.help()}>{d.ident()}</span>)
+            let ident = d.ident();
+            let onclick = onclick.reform(move |_| ident);
+            html!(<a {class} title={d.help()} {onclick}>{d.ident()}</a>)
         })
-    }
+    }}
 }
 
 /// Construct a convenient sequence callback which calls the given `builder`

--- a/crates/web/src/query.rs
+++ b/crates/web/src/query.rs
@@ -1,4 +1,6 @@
-use std::{borrow::Cow, rc::Rc};
+use std::borrow::Cow;
+use std::fmt::{self, Write};
+use std::rc::Rc;
 
 use web_sys::{window, Url};
 
@@ -23,7 +25,7 @@ pub enum Tab {
 
 #[derive(Debug)]
 pub(crate) struct Query {
-    pub(crate) text: Rc<str>,
+    pub(crate) text: String,
     pub(crate) translation: Option<String>,
     pub(crate) analyze_at: Option<usize>,
     pub(crate) index: usize,
@@ -34,8 +36,15 @@ pub(crate) struct Query {
 }
 
 impl Query {
+    pub(crate) fn append(&mut self, text: impl fmt::Display) {
+        if !self.text.is_empty() {
+            self.text.push(' ');
+            _ = write!(self.text, "{text}");
+        }
+    }
+
     /// Update query in the most common way.
-    pub(crate) fn set(&mut self, text: Rc<str>, translation: Option<String>) {
+    pub(crate) fn set(&mut self, text: String, translation: Option<String>) {
         self.text = text;
         self.translation = translation;
         self.analyze_at = None;
@@ -130,7 +139,7 @@ impl Query {
         }
 
         let this = Self {
-            text: text.into(),
+            text,
             translation,
             mode,
             capture_clipboard,
@@ -147,7 +156,7 @@ impl Query {
         let mut out = Vec::new();
 
         if !self.text.is_empty() {
-            out.push(("q", Cow::Borrowed(self.text.as_ref())));
+            out.push(("q", Cow::Borrowed(self.text.as_str())));
         }
 
         if let Some(t) = &self.translation {

--- a/crates/web/style/style.scss
+++ b/crates/web/style/style.scss
@@ -88,12 +88,36 @@ body {
 }
 
 #prompt {
+    display: flex;
+
     input[type="text"] {
-        width: 100%;
-        font-size: 1.4em;
+        flex-grow: 1;
+        height: 2.4rem;
+        font-size: 1em;
         box-sizing: border-box;
-        border-radius: 4px;
         border: 1px solid var(--input-border-primary);
+        border-radius: 0px;
+
+        border-top-left-radius: 4px;
+        border-bottom-left-radius: 4px;
+    }
+
+    button {
+        display: flex;
+        align-items: center;
+        height: 2.4rem;
+        font-size: 1em;
+        border: 1px solid var(--input-border-primary);
+        border-radius: 0px;
+
+        span {
+            font-size: 0.8em;
+        }
+
+        &:last-child {
+            border-top-right-radius: 4px;
+            border-bottom-right-radius: 4px;
+        }
     }
 }
 


### PR DESCRIPTION
Add support for all tags, and add the following meta tags:
* `#adjective` - matches any adjective.
* `#noun` - matches any noun.
* `#verb` - matches any verb.
* `#adverb` - matches any adverb.
* `#noun` - matches any noun.

![image](https://github.com/udoprog/jpv/assets/111092/a5ec8758-6d46-4909-bb53-52e8a4bef08e)

Additionaly, all priority tags are supported with or without value, like:
* `#nf` and `#nf28`.
* `#ichi` and `#ichi1`.

All bullets are now clickable, and will append the appropriate tag to the search field.

![image](https://github.com/udoprog/jpv/assets/111092/1649d046-9f8f-4978-ad2e-0512fc477c69)

Finally the search prompt has been made more compact:

![image](https://github.com/udoprog/jpv/assets/111092/79c90933-b436-439f-b125-91e192a24866)

Toggling input method:

![image](https://github.com/udoprog/jpv/assets/111092/25721851-c0e5-461d-88b1-85901f58afb8)
